### PR TITLE
fix: coveo-load-more-results-button is now a real button

### DIFF
--- a/src/LoadMoreResults.ts
+++ b/src/LoadMoreResults.ts
@@ -83,10 +83,10 @@ export class LoadMoreResults extends Component {
     }
 
     private renderLoadMoreButton(resultList: Coveo.ResultList) {
-      const loadMoreButton = $$('div', {
+      const loadMoreButton = $$('button', {
         className: 'coveo-load-more-results-button'
       }, Coveo.l('LoadMoreResults_Label'));
-      loadMoreButton.on('click', (e:Event) => { 
+      loadMoreButton.on('click', (e:Event) => {
           this.loadMoreResultsCount++;
           resultList.displayMoreResults(this.options.numberOfResultsPerLoad); })
 


### PR DESCRIPTION
Why not make the `div` holding the button a real `button`? For a11y purposes mainly, but not only.